### PR TITLE
Use registerTwigExtension()

### DIFF
--- a/src/CraftDumper.php
+++ b/src/CraftDumper.php
@@ -27,7 +27,7 @@ class CraftDumper extends \craft\base\Plugin
         parent::init();
 
         self::$plugin = $this;
-		Craft::$app->view->twig->addExtension( new DumperExtension() );
+		Craft::$app->view->registerTwigExtension( new DumperExtension() );
 
 	}
 }


### PR DESCRIPTION
Fixes a bug where the plugin may cause Twig to be loaded before it should be, and another bug where the extension might not be available if the Template Mode ever changes from CP to Site, or vise-versa.